### PR TITLE
feat: Add demo/mock mode to reduce external API dependency (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=https://dogsapi.origamid.dev/json
+VITE_DEMO_MODE=false

--- a/README.md
+++ b/README.md
@@ -143,7 +143,25 @@ Variável suportada:
 
 ```bash
 VITE_API_URL=https://dogsapi.origamid.dev/json
+VITE_DEMO_MODE=false
 ```
+
+### Modo Demo
+
+Para rodar sem depender da API externa, ative:
+
+```bash
+VITE_DEMO_MODE=true
+```
+
+Credenciais demo:
+
+```txt
+usuario: demo
+senha: Demo1234
+```
+
+Nesse modo, login, usuário, feed, upload e recuperação de senha usam dados mockados em memória. A API real continua sendo o padrão quando `VITE_DEMO_MODE` está ausente ou `false`.
 
 Contrato atual da API:
 
@@ -158,6 +176,7 @@ docs/API.md
 - Logout.
 - Cadastro de usuário.
 - Recuperação e redefinição de senha.
+- Modo demo/mock opcional.
 - Feed público com fotos reais.
 - Feed da conta filtrado por usuário logado.
 - Upload de foto autenticado.

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,49 @@ Os tipos compartilhados ficam em:
 src/types.ts
 ```
 
+## Modo Demo/Mock
+
+O frontend possui um modo demo opcional para reduzir dependencia da API externa.
+
+Ativacao:
+
+```bash
+VITE_DEMO_MODE=true
+```
+
+Comportamento padrao:
+
+```bash
+VITE_DEMO_MODE=false
+```
+
+Credenciais demo:
+
+```txt
+usuario: demo
+senha: Demo1234
+```
+
+No modo demo, `src/api.ts` troca os clientes reais por mocks definidos em:
+
+```txt
+src/mockApi.ts
+```
+
+Fluxos cobertos pelo mock:
+
+- login
+- validacao de token
+- usuario logado
+- cadastro
+- recuperacao de senha
+- redefinicao de senha
+- listagem de fotos
+- upload de foto
+- health check de fotos
+
+O modo demo nao substitui a futura API propria. Ele existe para manter o app navegavel em portfolio, dev e homologacao mesmo se a API externa estiver indisponivel.
+
 ## Estado Da API
 
 Validações feitas recentemente:
@@ -281,11 +324,10 @@ Recomendações:
 
 ## Fallback E Demo
 
-Ainda não existe fallback com dados mockados.
+O modo demo/mock já existe no frontend e pode ser ativado com `VITE_DEMO_MODE=true`.
 
 Opções futuras:
 
-- mock server local para portfólio
-- modo demo via `VITE_DEMO_MODE=true`
+- mock server local mais completo para portfólio
 - backend próprio hospedado com banco e storage de imagens
 - mensagens de erro mais ricas por tela quando a API externa estiver fora

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -50,6 +50,7 @@ Observação: React Router 7, Vite 8 e `@vitejs/plugin-react` 6 exigem Node 20+.
 - Base URL da API configurável via `VITE_API_URL`.
 - `.env.example` criado.
 - API client criado em `src/api.ts`.
+- Modo demo/mock criado em `src/mockApi.ts`, ativado por `VITE_DEMO_MODE=true`.
 - Tipos compartilhados criados em `src/types.ts`.
 - Health check da API criado em `scripts/check-api-health.mjs`.
 - CI/CD configurado em `.github/workflows/ci.yml`.
@@ -66,6 +67,7 @@ Observação: React Router 7, Vite 8 e `@vitejs/plugin-react` 6 exigem Node 20+.
 - Upload de foto autenticado.
 - Endpoints de recuperação de senha verificados na API pública.
 - Fluxo de recuperação e redefinição de senha implementado.
+- Login, usuário, feed, upload, senha e health check possuem mocks para modo demo.
 
 ## Issues Concluídas Localmente
 
@@ -78,6 +80,7 @@ Observação: React Router 7, Vite 8 e `@vitejs/plugin-react` 6 exigem Node 20+.
 - `16` Criar plano de saúde e contingência para API externa.
 - `21` Criar API client e configuração por ambiente.
 - `06` Completar fluxo de recuperação de senha.
+- `24` Adicionar modo demo/mock para reduzir dependência da API externa.
 
 Os arquivos dessas issues foram removidos de `docs/github-issues/` para manter o diretório focado no trabalho pendente.
 

--- a/docs/github-issues/PRIORITY.md
+++ b/docs/github-issues/PRIORITY.md
@@ -16,6 +16,7 @@ Concluídas localmente:
 - `21` Criar API client e configuração por ambiente.
 - `10` Adicionar CI/CD com GitHub Actions e GitHub Pages.
 - `06` Completar fluxo de recuperação de senha.
+- `24` Adicionar modo demo/mock para reduzir dependência da API externa.
 
 Pendentes:
 

--- a/docs/github-issues/README.md
+++ b/docs/github-issues/README.md
@@ -21,6 +21,7 @@ docs/github-issues/PRIORITY.md
 - `21` Criar API client e configuração por ambiente.
 - `10` Adicionar CI/CD com GitHub Actions e GitHub Pages.
 - `06` Completar fluxo de recuperação de senha.
+- `24` Adicionar modo demo/mock para reduzir dependência da API externa.
 
 ## Issues Pendentes
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,11 +8,19 @@ import type {
   User,
   UserCreateInput,
 } from './types';
+import {
+  mockAuthApi,
+  mockHealthApi,
+  mockPasswordApi,
+  mockPhotoApi,
+  mockUserApi,
+} from './mockApi';
 
 export const API_URL =
   import.meta.env.VITE_API_URL || 'https://dogsapi.origamid.dev/json';
 
 const TOKEN_KEY = 'token';
+export const IS_DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
 
 type ApiErrorOptions = {
   response?: Response;
@@ -140,7 +148,7 @@ export const tokenStorage = {
   remove: removeStoredToken,
 };
 
-export const authApi = {
+const realAuthApi = {
   login: (body: { username: string; password: string }) =>
     apiRequest<AuthTokenResponse>('/jwt-auth/v1/token', {
       method: 'POST',
@@ -154,7 +162,7 @@ export const authApi = {
     }),
 };
 
-export const userApi = {
+const realUserApi = {
   get: (token: string) =>
     apiRequest<User>('/api/user', {
       method: 'GET',
@@ -168,7 +176,7 @@ export const userApi = {
     }),
 };
 
-export const passwordApi = {
+const realPasswordApi = {
   lost: (body: PasswordLostInput) =>
     apiRequest<unknown>('/api/password/lost', {
       method: 'POST',
@@ -182,7 +190,7 @@ export const passwordApi = {
     }),
 };
 
-export const photoApi = {
+const realPhotoApi = {
   create: (formData: FormData, token: string | null) =>
     apiRequest<Photo>('/api/photo', {
       method: 'POST',
@@ -204,6 +212,12 @@ export const photoApi = {
   },
 };
 
-export const healthApi = {
-  photos: () => photoApi.list({ page: 1, total: 1, user: 0 }),
+const realHealthApi = {
+  photos: () => realPhotoApi.list({ page: 1, total: 1, user: 0 }),
 };
+
+export const authApi = IS_DEMO_MODE ? mockAuthApi : realAuthApi;
+export const userApi = IS_DEMO_MODE ? mockUserApi : realUserApi;
+export const passwordApi = IS_DEMO_MODE ? mockPasswordApi : realPasswordApi;
+export const photoApi = IS_DEMO_MODE ? mockPhotoApi : realPhotoApi;
+export const healthApi = IS_DEMO_MODE ? mockHealthApi : realHealthApi;

--- a/src/mockApi.ts
+++ b/src/mockApi.ts
@@ -1,0 +1,192 @@
+import type {
+  ApiResponse,
+  AuthTokenResponse,
+  PasswordLostInput,
+  PasswordResetInput,
+  Photo,
+  PhotoListParams,
+  User,
+  UserCreateInput,
+} from './types';
+
+const DEMO_TOKEN = 'demo-token';
+const DEMO_USERNAME = 'demo';
+const DEMO_PASSWORD = 'Demo1234';
+
+const demoUser: User = {
+  id: 1,
+  username: DEMO_USERNAME,
+  nome: 'Demo',
+  email: 'demo@dogs.local',
+};
+
+const demoPhotos: Photo[] = [
+  {
+    id: 101,
+    author: DEMO_USERNAME,
+    title: 'Nina',
+    src: 'https://images.unsplash.com/photo-1552053831-71594a27632d?auto=format&fit=crop&w=900&q=80',
+    peso: '18',
+    idade: '4',
+    acessos: 1532,
+  },
+  {
+    id: 102,
+    author: DEMO_USERNAME,
+    title: 'Thor',
+    src: 'https://images.unsplash.com/photo-1587300003388-59208cc962cb?auto=format&fit=crop&w=900&q=80',
+    peso: '24',
+    idade: '6',
+    acessos: 2841,
+  },
+  {
+    id: 103,
+    author: 'lucas',
+    title: 'Mel',
+    src: 'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?auto=format&fit=crop&w=900&q=80',
+    peso: '12',
+    idade: '3',
+    acessos: 987,
+  },
+  {
+    id: 104,
+    author: 'ana',
+    title: 'Bob',
+    src: 'https://images.unsplash.com/photo-1517849845537-4d257902454a?auto=format&fit=crop&w=900&q=80',
+    peso: '9',
+    idade: '2',
+    acessos: 745,
+  },
+  {
+    id: 105,
+    author: 'marina',
+    title: 'Luna',
+    src: 'https://images.unsplash.com/photo-1537151608828-ea2b11777ee8?auto=format&fit=crop&w=900&q=80',
+    peso: '15',
+    idade: '5',
+    acessos: 2190,
+  },
+  {
+    id: 106,
+    author: DEMO_USERNAME,
+    title: 'Oliva',
+    src: 'https://images.unsplash.com/photo-1561037404-61cd46aa615b?auto=format&fit=crop&w=900&q=80',
+    peso: '11',
+    idade: '1',
+    acessos: 608,
+  },
+];
+
+function delay(ms = 450): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function createResponse(status = 200): Response {
+  return new Response(null, {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+async function mockResponse<TData>(data: TData, status = 200): Promise<ApiResponse<TData>> {
+  await delay();
+  return {
+    response: createResponse(status),
+    data,
+  };
+}
+
+function createAuthError(): never {
+  throw new Error('Use usuario demo e senha Demo1234.');
+}
+
+export const mockAuthApi = {
+  login: async ({ username, password }: { username: string; password: string }) => {
+    await delay();
+    if (username !== DEMO_USERNAME || password !== DEMO_PASSWORD) createAuthError();
+
+    return {
+      response: createResponse(),
+      data: {
+        token: DEMO_TOKEN,
+        user_display_name: demoUser.nome,
+        user_email: demoUser.email,
+        user_nicename: demoUser.username,
+      } satisfies AuthTokenResponse,
+    };
+  },
+
+  validateToken: async (token: string) => {
+    await delay(250);
+    if (token !== DEMO_TOKEN) throw new Error('Token demo invalido.');
+
+    return {
+      response: createResponse(),
+      data: null,
+    };
+  },
+};
+
+export const mockUserApi = {
+  get: async (token: string) => {
+    await delay(250);
+    if (token !== DEMO_TOKEN) throw new Error('Usuario demo nao autenticado.');
+    return mockResponse<User>(demoUser, 200);
+  },
+
+  create: async (body: UserCreateInput) =>
+    mockResponse<User>(
+      {
+        id: 2,
+        username: body.username,
+        email: body.email,
+        nome: body.username,
+      },
+      201,
+    ),
+};
+
+export const mockPasswordApi = {
+  lost: async (_body: PasswordLostInput) => mockResponse<null>(null),
+
+  reset: async ({ key }: PasswordResetInput) => {
+    if (!key) throw new Error('Link de redefinicao invalido.');
+    return mockResponse<null>(null);
+  },
+};
+
+export const mockPhotoApi = {
+  create: async (formData: FormData) => {
+    const title = String(formData.get('nome') || 'Foto demo');
+    const photo: Photo = {
+      id: Date.now(),
+      author: DEMO_USERNAME,
+      title,
+      nome: title,
+      src: 'https://images.unsplash.com/photo-1507146426996-ef05306b995a?auto=format&fit=crop&w=900&q=80',
+      peso: String(formData.get('peso') || '0'),
+      idade: String(formData.get('idade') || '0'),
+      acessos: 0,
+    };
+
+    return mockResponse<Photo>(photo, 201);
+  },
+
+  list: async ({ page, total, user }: PhotoListParams) => {
+    const photos =
+      String(user) === '0'
+        ? demoPhotos
+        : demoPhotos.filter((photo) => photo.author === DEMO_USERNAME);
+    const start = (page - 1) * total;
+
+    return mockResponse<Photo[]>(photos.slice(start, start + total));
+  },
+};
+
+export const mockHealthApi = {
+  photos: () => mockPhotoApi.list({ page: 1, total: 1, user: 0 }),
+};


### PR DESCRIPTION
Introduces an optional demo mode that allows the frontend to operate independently of the external API by replacing real API clients with in-memory mock implementations. This ensures the application remains navigable for development, portfolio showcases, and homologation, even if the external API is unavailable.

The mode covers essential flows including login, user validation, registration, password recovery/reset, photo listing, and photo upload. It is activated via the `VITE_DEMO_MODE=true` environment variable.