### PR TITLE
docs: Add frontend integration handoff and backlog for Dogs API

### DIFF
--- a/docs/FRONTEND_INTEGRATION_HANDOFF.md
+++ b/docs/FRONTEND_INTEGRATION_HANDOFF.md
@@ -1,0 +1,243 @@
+# Frontend Integration Handoff
+
+Este documento orienta a integração do frontend `react-dogs` com a `dogs-api`.
+
+## Estado Do Backend
+
+A Dogs API já possui:
+
+- Supabase Auth como provedor de identidade.
+- Perfil local `User` sincronizado pela API.
+- Catálogo de raças.
+- CRUD inicial de cachorros com memberships.
+- Posts/feed público.
+- Upload multipart de imagem para Supabase Storage.
+- Swagger em `/docs`.
+- OpenAPI JSON em `/docs-json`.
+- Collection Insomnia em `docs/http/dogs-api.insomnia.json`.
+
+## Base URL
+
+Local:
+
+```txt
+http://localhost:3333
+```
+
+Dev/prod ainda devem ser configurados quando houver deploy.
+
+## Autenticação
+
+O frontend deve autenticar diretamente com Supabase Auth.
+
+Fluxo:
+
+```txt
+Frontend -> Supabase Auth
+Supabase retorna session/access_token
+Frontend -> Dogs API com Authorization: Bearer <access_token>
+Dogs API valida token no Supabase
+Dogs API cria/sincroniza perfil local
+```
+
+Header para endpoints autenticados:
+
+```txt
+Authorization: Bearer <supabase_access_token>
+```
+
+O frontend não deve chamar endpoints de login/senha na Dogs API. Cadastro, login, logout, refresh, recuperação de senha e OAuth ficam no Supabase.
+
+## Endpoints De Auth/User
+
+```txt
+GET   /v1/auth/me
+POST  /v1/auth/sync
+GET   /v1/users/me
+PATCH /v1/users/me
+```
+
+Uso recomendado:
+
+1. Depois do login Supabase, chamar `POST /v1/auth/sync` ou `GET /v1/auth/me`.
+2. Guardar o perfil local retornado pela Dogs API no estado do app.
+3. Usar `PATCH /v1/users/me` para edição do perfil do tutor.
+
+## Breeds
+
+Públicos:
+
+```txt
+GET /v1/breeds
+GET /v1/breeds/:slug
+```
+
+Uso no frontend:
+
+- Carregar raças para selects/filtros.
+- Usar `breed.id` ao criar cachorro.
+- Usar `breed.slug` em filtros públicos.
+
+## Dogs
+
+Públicos:
+
+```txt
+GET /v1/dogs
+GET /v1/dogs/:slug
+```
+
+Autenticados:
+
+```txt
+POST   /v1/dogs
+PATCH  /v1/dogs/:dogId
+DELETE /v1/dogs/:dogId
+GET    /v1/dogs/:dogId/members
+```
+
+Regras importantes:
+
+- Ao criar cachorro, a API cria membership `owner` para o usuário autenticado.
+- Apenas `owner` ou `editor` edita.
+- Apenas `owner` remove.
+- Listagem pública mostra apenas `isPublic=true`.
+
+Filtros em `GET /v1/dogs`:
+
+```txt
+breed
+city
+state
+interest
+page
+perPage
+```
+
+## Posts E Feed
+
+Públicos:
+
+```txt
+GET /v1/posts
+GET /v1/posts/:postId
+```
+
+Autenticados:
+
+```txt
+POST   /v1/posts
+PATCH  /v1/posts/:postId
+DELETE /v1/posts/:postId
+```
+
+Regras importantes:
+
+- Apenas tutor ativo do cachorro pode publicar.
+- `DELETE` usa soft delete.
+- Feed retorna apenas posts públicos, publicados e não deletados.
+
+Filtros em `GET /v1/posts`:
+
+```txt
+dog
+breed
+city
+state
+page
+perPage
+```
+
+## Media Upload
+
+Autenticado:
+
+```txt
+POST /v1/media
+```
+
+Multipart form-data:
+
+```txt
+postId=<id do post>
+file=<imagem>
+```
+
+Validações atuais:
+
+- arquivo obrigatório;
+- MIME permitido: `image/jpeg`, `image/png`, `image/webp`;
+- tamanho máximo: `5 MB`;
+- usuário precisa ser `owner` ou `editor` do cachorro do post.
+
+Resposta cria um registro `Media` e retorna URL pública do Supabase Storage.
+
+## Contrato De Resposta
+
+Item:
+
+```json
+{
+  "data": {}
+}
+```
+
+Lista:
+
+```json
+{
+  "data": [],
+  "pagination": {
+    "page": 1,
+    "perPage": 12,
+    "total": 0,
+    "totalPages": 1
+  }
+}
+```
+
+Erro:
+
+```json
+{
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "Token de autenticação ausente.",
+    "details": []
+  }
+}
+```
+
+## Ordem Recomendada Para Migrar O Frontend
+
+1. Instalar/configurar Supabase client no frontend.
+2. Implementar login/logout/session listener com Supabase Auth.
+3. Criar client HTTP da Dogs API com `Authorization: Bearer <token>`.
+4. Trocar fluxo de `user` por `GET /v1/users/me` e `PATCH /v1/users/me`.
+5. Trocar catálogo de raças por `GET /v1/breeds`.
+6. Migrar criação/listagem de cachorros para `/v1/dogs`.
+7. Migrar feed para `/v1/posts`.
+8. Migrar criação de post:
+   - criar post com `POST /v1/posts`;
+   - subir imagem com `POST /v1/media`.
+9. Remover chamadas da API antiga quando os fluxos estiverem estáveis.
+
+## Variáveis Esperadas No Frontend
+
+Sugestão:
+
+```txt
+VITE_DOGS_API_URL=http://localhost:3333
+VITE_SUPABASE_URL=https://seu-projeto.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_...
+```
+
+Nunca expor service role key no frontend.
+
+## Observações Para O Codex No Front
+
+- Preferir adaptar chamadas existentes gradualmente em vez de reescrever telas inteiras.
+- Manter a API antiga apenas como fallback temporário se necessário.
+- Mapear cuidadosamente diferenças de contrato entre API antiga e Dogs API.
+- Para upload, usar `FormData`.
+- Para requests autenticados, buscar token da sessão atual do Supabase antes da chamada.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-Atualizado em 2026-06-04.
+Atualizado em 2026-06-07.
 
 ## Resumo
 
@@ -149,11 +149,22 @@ Os arquivos dessas issues foram removidos de `docs/github-issues/` para manter o
 
 ## Próxima Frente
 
-Não há issues pendentes planejadas neste diretório para a fase atual. As próximas frentes devem nascer como novas issues, preferencialmente separando frontend e backend.
+A próxima frente planejada é integrar o frontend `react-dogs` com a nova `dogs-api`, usando o handoff em `docs/FRONTEND_INTEGRATION_HANDOFF.md`.
+
+Issues pendentes criadas para essa fase:
+
+- `27` Configurar Supabase Auth no frontend.
+- `28` Criar client da Dogs API com contrato novo.
+- `29` Migrar perfil do usuário para Dogs API.
+- `30` Integrar catálogo de raças e CRUD de cachorros.
+- `31` Migrar feed público e modal para posts.
+- `32` Migrar publicação com upload multipart.
+- `33` Ajustar ambientes, CI/CD e documentação da integração.
 
 ## Ainda Pendente
 
-- Criar a API própria em outro repositório.
+- Integrar o frontend com a API própria criada em outro repositório.
+- Configurar URLs hml/prod da Dogs API e envs públicas do Supabase no build do frontend.
 - Adicionar mais capturas ou GIFs dos principais fluxos do app.
 - Evoluir testes de integração para fluxos completos de usuário.
 

--- a/docs/github-issues/27-configurar-supabase-auth-no-frontend.md
+++ b/docs/github-issues/27-configurar-supabase-auth-no-frontend.md
@@ -1,0 +1,26 @@
+# Configurar Supabase Auth no frontend
+
+## Contexto
+
+A nova `dogs-api` usa Supabase Auth como provedor de identidade. O frontend deve autenticar diretamente no Supabase e enviar o `access_token` para a Dogs API no header `Authorization`.
+
+## Objetivo
+
+Trocar o fluxo de autenticação atual baseado nos endpoints JWT da API antiga por Supabase Auth no frontend.
+
+## Tarefas
+
+- Instalar e configurar `@supabase/supabase-js`.
+- Adicionar suporte a `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`.
+- Criar um client Supabase centralizado para o app.
+- Migrar login, logout, cadastro, recuperação de senha, reset de senha e listener de sessão para Supabase Auth.
+- Remover a dependência dos endpoints antigos `/jwt-auth/v1/token` e `/jwt-auth/v1/token/validate`.
+- Preservar modo demo/mock quando `VITE_DEMO_MODE=true`.
+
+## Critérios De Aceite
+
+- Usuário consegue entrar, sair e manter sessão via Supabase Auth.
+- O estado global de autenticação reflete a sessão Supabase.
+- Nenhuma service role key é usada ou documentada no frontend.
+- Fluxos de auth existentes continuam com feedback de erro e loading.
+- Testes relevantes de auth continuam passando ou são atualizados.

--- a/docs/github-issues/28-criar-client-da-dogs-api-com-contrato-novo.md
+++ b/docs/github-issues/28-criar-client-da-dogs-api-com-contrato-novo.md
@@ -1,0 +1,32 @@
+# Criar client da Dogs API com contrato novo
+
+## Contexto
+
+A API antiga usa endpoints e formatos diferentes da nova `dogs-api`. A nova API retorna itens em `{ "data": {} }`, listas em `{ "data": [], "pagination": {} }` e erros em `{ "error": { ... } }`.
+
+## Objetivo
+
+Criar/adaptar o client HTTP do frontend para consumir a Dogs API com tipagem, URL própria e autenticação via Bearer token do Supabase.
+
+## Tarefas
+
+- Introduzir `VITE_DOGS_API_URL`, com fallback local para `http://localhost:3333`.
+- Adaptar `apiRequest` para parsear respostas `{ data, pagination }` e erros `{ error }`.
+- Enviar `Authorization: Bearer <supabase_access_token>` em chamadas autenticadas.
+- Criar APIs tipadas para:
+  - `auth/me` e `auth/sync`;
+  - `users/me`;
+  - `breeds`;
+  - `dogs`;
+  - `posts`;
+  - `media`.
+- Manter compatibilidade temporária com mocks quando necessário.
+- Atualizar tipos compartilhados para refletir entidades da Dogs API.
+
+## Critérios De Aceite
+
+- Chamadas públicas funcionam sem token.
+- Chamadas autenticadas usam o token atual do Supabase.
+- Erros da Dogs API aparecem com mensagem amigável no app.
+- `VITE_API_URL` deixa de ser a env principal da integração nova.
+- O client fica preparado para paginação em listas.

--- a/docs/github-issues/29-migrar-perfil-do-usuario-para-dogs-api.md
+++ b/docs/github-issues/29-migrar-perfil-do-usuario-para-dogs-api.md
@@ -1,0 +1,24 @@
+# Migrar perfil do usuário para Dogs API
+
+## Contexto
+
+Depois do login pelo Supabase, a Dogs API cria ou sincroniza um perfil local de usuário. O frontend deve guardar esse perfil local no estado do app.
+
+## Objetivo
+
+Migrar o fluxo de usuário atual para os endpoints `/v1/auth/sync`, `/v1/auth/me`, `/v1/users/me` e `PATCH /v1/users/me`.
+
+## Tarefas
+
+- Após login ou restauração de sessão Supabase, chamar `POST /v1/auth/sync` ou `GET /v1/auth/me`.
+- Guardar o perfil local retornado pela Dogs API no Zustand.
+- Trocar o carregamento de usuário atual por `GET /v1/users/me`.
+- Implementar atualização do perfil do tutor com `PATCH /v1/users/me`, quando houver tela/campo disponível.
+- Ajustar tipos, mocks e testes ligados ao usuário autenticado.
+
+## Critérios De Aceite
+
+- Sessão Supabase válida carrega perfil local da Dogs API.
+- Logout limpa sessão Supabase, token derivado e perfil local.
+- Rotas protegidas continuam funcionando.
+- Falha de sincronização mostra feedback claro e não deixa estado inconsistente.

--- a/docs/github-issues/30-integrar-catalogo-de-racas-e-crud-de-cachorros.md
+++ b/docs/github-issues/30-integrar-catalogo-de-racas-e-crud-de-cachorros.md
@@ -1,0 +1,26 @@
+# Integrar catálogo de raças e CRUD de cachorros
+
+## Contexto
+
+A Dogs API separa cachorros de posts. O frontend atual trata o cadastro de foto como cadastro de cachorro/foto da API antiga, então o fluxo precisa ser adaptado gradualmente.
+
+## Objetivo
+
+Consumir o catálogo de raças e migrar criação/listagem/edição de cachorros para `/v1/dogs`.
+
+## Tarefas
+
+- Consumir `GET /v1/breeds` para selects e filtros.
+- Usar `breed.id` ao criar ou editar cachorro.
+- Usar `breed.slug` em filtros públicos quando aplicável.
+- Adaptar criação de cachorro para `POST /v1/dogs`.
+- Adaptar edição e remoção para `PATCH /v1/dogs/:dogId` e `DELETE /v1/dogs/:dogId`.
+- Adaptar listagem pública para `GET /v1/dogs` com filtros `breed`, `city`, `state`, `interest`, `page` e `perPage`.
+- Respeitar regras de permissão: owner/editor edita; apenas owner remove.
+
+## Critérios De Aceite
+
+- Raças carregam da Dogs API.
+- Cachorros públicos aparecem usando o contrato novo.
+- Usuário autenticado consegue criar cachorro e vira owner.
+- Estados de loading, erro e vazio seguem o padrão visual atual.

--- a/docs/github-issues/31-migrar-feed-publico-e-modal-para-posts.md
+++ b/docs/github-issues/31-migrar-feed-publico-e-modal-para-posts.md
@@ -1,0 +1,26 @@
+# Migrar feed público e modal para posts
+
+## Contexto
+
+Na Dogs API, o feed público vem de `/v1/posts`, não de fotos da API antiga. Posts podem ter mídia, cachorro relacionado e dados de tutor.
+
+## Objetivo
+
+Migrar o feed público e o modal de detalhes para consumir posts da Dogs API.
+
+## Tarefas
+
+- Trocar `photoApi.list` por `GET /v1/posts`.
+- Trocar `photoApi.get` por `GET /v1/posts/:postId`.
+- Mapear imagem principal a partir da mídia retornada pelo post.
+- Mapear título, tutor, cachorro, visualizações ou metadados disponíveis mantendo o layout atual.
+- Implementar filtros suportados: `dog`, `breed`, `city`, `state`, `page` e `perPage`.
+- Adaptar estados vazios e mensagens para posts.
+- Atualizar mocks e testes do feed/modal.
+
+## Critérios De Aceite
+
+- Feed público lista apenas posts públicos retornados pela Dogs API.
+- Modal abre detalhes de um post usando o contrato novo.
+- Paginação/filtros ficam preparados para evolução sem quebrar o layout atual.
+- Testes de feed e item do feed refletem posts em vez de fotos antigas.

--- a/docs/github-issues/32-migrar-publicacao-com-upload-multipart.md
+++ b/docs/github-issues/32-migrar-publicacao-com-upload-multipart.md
@@ -1,0 +1,29 @@
+# Migrar publicação com upload multipart
+
+## Contexto
+
+A Dogs API cria post e mídia em etapas separadas: primeiro `POST /v1/posts`, depois `POST /v1/media` com multipart form-data.
+
+## Objetivo
+
+Adaptar o fluxo atual de publicação para criar post e enviar imagem para Supabase Storage via Dogs API.
+
+## Tarefas
+
+- Adaptar a tela atual de postagem para selecionar um cachorro existente ou criar um fluxo equivalente.
+- Criar post com `POST /v1/posts`.
+- Enviar imagem com `POST /v1/media` usando `postId` e `file`.
+- Validar no frontend:
+  - arquivo obrigatório;
+  - MIME `image/jpeg`, `image/png` ou `image/webp`;
+  - tamanho máximo de 5 MB.
+- Tratar falha na criação do post ou no upload com feedback claro.
+- Atualizar preview, loading, erro e navegação pós-sucesso.
+- Atualizar testes e mocks do fluxo.
+
+## Critérios De Aceite
+
+- Usuário autenticado consegue publicar um post com imagem.
+- Upload usa multipart com os campos esperados pela Dogs API.
+- Arquivos inválidos são bloqueados antes da requisição.
+- Falhas parciais não deixam o usuário sem feedback.

--- a/docs/github-issues/33-ajustar-ambientes-ci-cd-e-documentacao-da-integracao.md
+++ b/docs/github-issues/33-ajustar-ambientes-ci-cd-e-documentacao-da-integracao.md
@@ -1,0 +1,29 @@
+# Ajustar ambientes, CI/CD e documentação da integração
+
+## Contexto
+
+Quando a `dogs-api` tiver ambientes de homologação e produção, o frontend precisa buildar cada branch com a URL correta da API e as envs públicas do Supabase.
+
+## Objetivo
+
+Atualizar configuração, documentação e esteira para suportar Dogs API em dev/hml e produção.
+
+## Tarefas
+
+- Atualizar `.env.example` com:
+  - `VITE_DOGS_API_URL`;
+  - `VITE_SUPABASE_URL`;
+  - `VITE_SUPABASE_ANON_KEY`;
+  - `VITE_DEMO_MODE`.
+- Atualizar README, `docs/DEPLOYMENT.md` e guias relacionados.
+- Ajustar GitHub Actions para injetar envs diferentes no build de `develop` e `main`.
+- Definir `develop` como ambiente hml/dev do front e `main` como produção.
+- Atualizar `scripts/check-api-health.mjs` para a Dogs API.
+- Documentar que service role key nunca entra no frontend.
+
+## Critérios De Aceite
+
+- Build local continua funcionando com `.env.local`.
+- Build de `develop` usa URL/envs de hml/dev.
+- Build de `main` usa URL/envs de produção.
+- Documentação explica quais envs configurar no GitHub e no provedor da API.

--- a/docs/github-issues/PRIORITY.md
+++ b/docs/github-issues/PRIORITY.md
@@ -1,6 +1,6 @@
 # Ordem Recomendada Das Issues
 
-Todas as issues planejadas para esta fase foram concluídas localmente.
+Fila atual para integrar o frontend `react-dogs` com a nova `dogs-api`.
 
 ## Status Atual
 
@@ -35,30 +35,52 @@ Concluídas localmente:
 
 Pendentes:
 
-- Nenhuma issue pendente neste diretório.
+- `27` Configurar Supabase Auth no frontend.
+- `28` Criar client da Dogs API com contrato novo.
+- `29` Migrar perfil do usuário para Dogs API.
+- `30` Integrar catálogo de raças e CRUD de cachorros.
+- `31` Migrar feed público e modal para posts.
+- `32` Migrar publicação com upload multipart.
+- `33` Ajustar ambientes, CI/CD e documentação da integração.
 
 ## Próxima Issue Recomendada
 
 ```txt
-Sem issue pendente planejada
+27 Configurar Supabase Auth no frontend
 ```
 
-Motivo: o backlog local planejado foi concluído. Para continuar, crie novas issues para backend próprio, screenshots, observabilidade ou melhorias de produto.
+Motivo: a nova Dogs API recebe token emitido pelo Supabase. A autenticação precisa mudar antes de integrar endpoints autenticados.
+
+## Priority High
+
+- `27` Configurar Supabase Auth no frontend.
+- `28` Criar client da Dogs API com contrato novo.
+- `29` Migrar perfil do usuário para Dogs API.
+- `33` Ajustar ambientes, CI/CD e documentação da integração.
 
 ## Priority Medium
 
-Nenhuma issue pendente.
+- `30` Integrar catálogo de raças e CRUD de cachorros.
+- `31` Migrar feed público e modal para posts.
+- `32` Migrar publicação com upload multipart.
 
 ## Ordem Funcional Recomendada
 
-Nenhuma issue pendente.
+1. `27` Configurar Supabase Auth no frontend.
+2. `28` Criar client da Dogs API com contrato novo.
+3. `29` Migrar perfil do usuário para Dogs API.
+4. `30` Integrar catálogo de raças e CRUD de cachorros.
+5. `31` Migrar feed público e modal para posts.
+6. `32` Migrar publicação com upload multipart.
+7. `33` Ajustar ambientes, CI/CD e documentação da integração.
 
 ## Critério Para Reordenar
 
 Reordene a fila se uma issue desbloquear claramente outra. Exemplos:
 
-- Se o modal exigir uma reorganização pesada, considerar `20` antes de continuar produto.
-- Se a esteira precisar de deploy externo alem de GitHub Pages, criar uma nova issue especifica de CD.
+- Se `33` bloquear validação em ambiente publicado, antecipar antes dos fluxos de produto.
+- Se o backend adicionar endpoint de estatísticas, criar uma nova issue específica para substituir `/api/stats`.
+- Se o fluxo de publicação exigir nova tela de gestão de cachorros, dividir `30` antes de iniciar `32`.
 
 ## Histórico
 

--- a/docs/github-issues/README.md
+++ b/docs/github-issues/README.md
@@ -2,6 +2,12 @@
 
 Este diretório contém apenas issues pendentes. As issues já concluídas localmente foram removidas para manter o backlog menor e mais fácil de executar.
 
+A fila atual é focada na integração do frontend `react-dogs` com a nova `dogs-api`, conforme o handoff em:
+
+```txt
+docs/FRONTEND_INTEGRATION_HANDOFF.md
+```
+
 Para histórico do que já foi feito, consulte:
 
 ```txt
@@ -40,15 +46,21 @@ docs/github-issues/PRIORITY.md
 
 ## Issues Pendentes
 
-Nenhuma issue pendente neste diretório.
+- `27` Configurar Supabase Auth no frontend.
+- `28` Criar client da Dogs API com contrato novo.
+- `29` Migrar perfil do usuário para Dogs API.
+- `30` Integrar catálogo de raças e CRUD de cachorros.
+- `31` Migrar feed público e modal para posts.
+- `32` Migrar publicação com upload multipart.
+- `33` Ajustar ambientes, CI/CD e documentação da integração.
 
 ## Próxima Issue Recomendada
 
 ```txt
-Sem issue pendente planejada
+27 Configurar Supabase Auth no frontend
 ```
 
-Motivo: o backlog local planejado foi concluído. Para continuar, crie novas issues para backend próprio, screenshots, observabilidade ou melhorias de produto.
+Motivo: a Dogs API valida tokens do Supabase. O frontend precisa primeiro autenticar diretamente no Supabase para que as próximas integrações possam enviar `Authorization: Bearer <supabase_access_token>`.
 
 ## Como Publicar No GitHub
 
@@ -65,6 +77,8 @@ bash docs/github-issues/create-issues.sh
 ```
 
 Também dá para criar issues individualmente com `gh issue create` usando um arquivo markdown como corpo.
+
+O script é idempotente: ele consulta issues abertas e fechadas por título exato e pula qualquer card que já exista.
 
 ## Labels Usadas
 
@@ -94,7 +108,16 @@ docs/github-issues/PRIORITY.md
 
 Resumo:
 
-O backlog planejado para esta fase foi concluído. Novas frentes devem ser criadas como novas issues antes de iniciar implementação.
+Comece por Supabase Auth, depois client da Dogs API, perfil local, cachorros, posts/feed, upload e, por fim, envs/CI/docs.
+
+## Ambientes Da Nova API
+
+Quando a `dogs-api` tiver ambientes publicados:
+
+- `develop` do front deve apontar para hml/dev da API e publicar em `/react-dogs/dev/`.
+- `main` do front deve apontar para produção da API e publicar em `/react-dogs/`.
+- O build do front deve receber `VITE_DOGS_API_URL`, `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY` por ambiente.
+- Nunca use service role key do Supabase no frontend.
 
 ## Observações
 

--- a/docs/github-issues/create-issues.sh
+++ b/docs/github-issues/create-issues.sh
@@ -22,4 +22,60 @@ ensure_label "priority-high" "b60205" "Alta prioridade"
 ensure_label "priority-medium" "fbca04" "Media prioridade"
 ensure_label "priority-low" "cfd3d7" "Baixa prioridade"
 
-echo "Labels sincronizadas. Nao ha issues pendentes para criar neste diretorio."
+create_issue_if_missing() {
+  local title="$1"
+  local body_file="$2"
+  shift 2
+  local labels=("$@")
+
+  if gh issue list --state all --limit 1000 --json title --jq '.[].title' | grep -Fxq "$title"; then
+    echo "Issue ja existe, pulando: $title"
+    return
+  fi
+
+  local args=(issue create --title "$title" --body-file "$body_file")
+  local label
+
+  for label in "${labels[@]}"; do
+    args+=(--label "$label")
+  done
+
+  gh "${args[@]}"
+}
+
+create_issue_if_missing \
+  "27 Configurar Supabase Auth no frontend" \
+  "docs/github-issues/27-configurar-supabase-auth-no-frontend.md" \
+  feature priority-high
+
+create_issue_if_missing \
+  "28 Criar client da Dogs API com contrato novo" \
+  "docs/github-issues/28-criar-client-da-dogs-api-com-contrato-novo.md" \
+  tech-debt priority-high
+
+create_issue_if_missing \
+  "29 Migrar perfil do usuário para Dogs API" \
+  "docs/github-issues/29-migrar-perfil-do-usuario-para-dogs-api.md" \
+  feature priority-high
+
+create_issue_if_missing \
+  "30 Integrar catálogo de raças e CRUD de cachorros" \
+  "docs/github-issues/30-integrar-catalogo-de-racas-e-crud-de-cachorros.md" \
+  feature priority-medium
+
+create_issue_if_missing \
+  "31 Migrar feed público e modal para posts" \
+  "docs/github-issues/31-migrar-feed-publico-e-modal-para-posts.md" \
+  feature priority-medium
+
+create_issue_if_missing \
+  "32 Migrar publicação com upload multipart" \
+  "docs/github-issues/32-migrar-publicacao-com-upload-multipart.md" \
+  feature priority-medium
+
+create_issue_if_missing \
+  "33 Ajustar ambientes, CI/CD e documentação da integração" \
+  "docs/github-issues/33-ajustar-ambientes-ci-cd-e-documentacao-da-integracao.md" \
+  ci documentation priority-high
+
+echo "Backlog da integracao Dogs API sincronizado."


### PR DESCRIPTION
Provides a comprehensive guide (`FRONTEND_INTEGRATION_HANDOFF.md`) for integrating the `react-dogs` frontend with the `dogs-api` backend.

This commit also establishes the complete integration backlog by:
- Creating detailed markdown files for individual GitHub issues (e.g., Supabase Auth, API client, user profile, dogs, posts, media upload).
- Updating the `create-issues.sh` script to automatically generate these issues.
- Refreshing `PRIORITY.md`, `README.md`, and `PROJECT_STATUS.md` to reflect the new integration phase and recommended task order.

This sets up the entire work stream for the frontend migration.