### PR TITLE
fix: use configured Dogs API URL in test

### DIFF
--- a/src/Components/User/UserPhotoPost.test.tsx
+++ b/src/Components/User/UserPhotoPost.test.tsx
@@ -62,6 +62,11 @@ const renderUserPhotoPost = () =>
     { initialEntries: ['/conta/postar'] },
   );
 
+const selectDog = async () => {
+  await screen.findByRole('option', { name: dog.name });
+  await userEvent.selectOptions(screen.getByLabelText('Cachorro'), dog.id);
+};
+
 describe('UserPhotoPost', () => {
   beforeEach(() => {
     mockedDogList.mockReset();
@@ -77,7 +82,7 @@ describe('UserPhotoPost', () => {
 
     const file = new File(['image'], 'nina.jpg', { type: 'image/jpeg' });
 
-    await userEvent.selectOptions(await screen.findByLabelText('Cachorro'), dog.id);
+    await selectDog();
     await userEvent.type(screen.getByLabelText('Legenda'), 'Nina no parque');
     await userEvent.upload(screen.getByLabelText('Imagem'), file);
     await userEvent.click(screen.getByRole('button', { name: /publicar/i }));
@@ -101,7 +106,7 @@ describe('UserPhotoPost', () => {
 
     const file = new File(['image'], 'nina.gif', { type: 'image/gif' });
 
-    await userEvent.selectOptions(await screen.findByLabelText('Cachorro'), dog.id);
+    await selectDog();
     await userEvent.upload(screen.getByLabelText('Imagem'), file, { applyAccept: false });
     await userEvent.click(screen.getByRole('button', { name: /publicar/i }));
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { dogsApiRequest, tokenStorage } from './api';
+import { DOGS_API_URL, dogsApiRequest, tokenStorage } from './api';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -33,7 +33,7 @@ describe('dogsApiRequest', () => {
 
     const result = await dogsApiRequest('/v1/breeds');
 
-    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3333/v1/breeds');
+    expect(fetchMock.mock.calls[0][0]).toBe(`${DOGS_API_URL}/v1/breeds`);
     expect(result.data).toEqual([
       { id: 'breed-1', name: 'Golden Retriever', slug: 'golden-retriever' },
     ]);


### PR DESCRIPTION
## Resumo
- remove a expectativa fixa de localhost do teste do client
- usa a URL configurada em VITE_DOGS_API_URL
- destrava a esteira quando o ambiente de dev aponta para o Render

## Validação
- yarn lint
- yarn typecheck
- yarn test (39 testes)
- yarn build