### PR TITLE
fix: improve GitHub Pages SPA routing and feed content fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,28 +197,22 @@ jobs:
 
       - name: Add SPA fallbacks
         run: |
-          if [ -f site/index.html ]; then
-            cp site/index.html site/404.html
-          elif [ -f site/dev/index.html ]; then
-            printf '%s\n' \
-              '<!doctype html>' \
-              '<html lang="pt-BR">' \
-              '  <head>' \
-              '    <meta charset="UTF-8" />' \
-              '    <meta http-equiv="refresh" content="0; url=/react-dogs/dev/" />' \
-              '    <title>Dogs</title>' \
-              '  </head>' \
-              '  <body>' \
-              '    <p>Redirecionando para o ambiente dev...</p>' \
-              '  </body>' \
-              '</html>' \
-              > site/index.html
-            cp site/index.html site/404.html
-          fi
-
-          if [ -f site/dev/index.html ]; then
-            cp site/dev/index.html site/dev/404.html
-          fi
+          printf '%s\n' \
+            '<!doctype html>' \
+            '<html lang="pt-BR">' \
+            '  <head>' \
+            '    <meta charset="UTF-8" />' \
+            '    <title>Dogs</title>' \
+            '    <script>' \
+            '      const path = window.location.pathname;' \
+            "      const base = path.startsWith('/react-dogs/dev/') ? '/react-dogs/dev/' : '/react-dogs/';" \
+            '      const route = path + window.location.search;' \
+            "      window.location.replace(base + '?__route=' + encodeURIComponent(route) + window.location.hash);" \
+            '    </script>' \
+            '  </head>' \
+            '  <body></body>' \
+            '</html>' \
+            > site/404.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/src/Components/Feed/FeedPhotos.styles.ts
+++ b/src/Components/Feed/FeedPhotos.styles.ts
@@ -1,9 +1,13 @@
 import styled from '@emotion/styled';
 
 export const EmptyMessage = styled.p`
+  display: grid;
+  min-height: 12rem;
+  place-items: center;
+  text-align: center;
   color: ${({ theme }) => theme.colors.textMuted};
   font-size: 1rem;
-  margin: ${({ theme }) => theme.spacing.xxxl} 0;
+  margin: 0;
 `;
 
 export const FeedList = styled.ul`
@@ -14,5 +18,20 @@ export const FeedList = styled.ul`
 
   @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
     grid-template-columns: repeat(2, 1fr);
+  }
+`;
+
+export const LegacyPhotoContent = styled.article`
+  display: grid;
+  height: 100%;
+  overflow: hidden;
+  border-radius: ${({ theme }) => theme.radii.sm};
+
+  img {
+    grid-area: 1 / 1;
+    width: 100%;
+    height: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
   }
 `;

--- a/src/Components/Feed/FeedPhotos.test.tsx
+++ b/src/Components/Feed/FeedPhotos.test.tsx
@@ -2,13 +2,16 @@ import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { postsApi } from '@/api';
+import { photoApi, postsApi } from '@/api';
 import { renderWithProviders } from '@/test/renderWithProviders';
-import type { ApiResponse, Post } from '@/types';
+import type { ApiResponse, Photo, Post } from '@/types';
 
 import FeedPhotos from './FeedPhotos';
 
 vi.mock('@/api', () => ({
+  photoApi: {
+    list: vi.fn(),
+  },
   postsApi: {
     list: vi.fn(),
   },
@@ -34,20 +37,32 @@ const posts: Post[] = [
   },
 ];
 
+const legacyPhotos: Photo[] = [
+  {
+    id: 1,
+    title: 'Joel',
+    src: 'https://example.com/joel.jpg',
+  },
+];
+
 const createApiResponse = <TData,>(data: TData): ApiResponse<TData> => ({
   response: new Response(null, { status: 200 }),
   data,
 });
 
-const mockedList = vi.mocked(postsApi.list);
+const mockedPostsList = vi.mocked(postsApi.list);
+const mockedPhotosList = vi.mocked(photoApi.list);
 
 describe('FeedPhotos', () => {
   beforeEach(() => {
-    mockedList.mockReset();
+    mockedPostsList.mockReset();
+    mockedPhotosList.mockReset();
+    mockedPhotosList.mockResolvedValue(createApiResponse([]));
   });
 
   it('shows loading while photos are requested', async () => {
-    mockedList.mockReturnValue(new Promise(() => undefined));
+    mockedPostsList.mockReturnValue(new Promise(() => undefined));
+    mockedPhotosList.mockReturnValue(new Promise(() => undefined));
 
     renderWithProviders(<FeedPhotos onSelectPost={vi.fn()} />);
 
@@ -55,7 +70,7 @@ describe('FeedPhotos', () => {
   });
 
   it('renders an error message when the request fails', async () => {
-    mockedList.mockRejectedValue(new Error('Falha ao buscar posts.'));
+    mockedPostsList.mockRejectedValue(new Error('Falha ao buscar posts.'));
 
     renderWithProviders(<FeedPhotos onSelectPost={vi.fn()} />);
 
@@ -63,7 +78,7 @@ describe('FeedPhotos', () => {
   });
 
   it('renders the empty state when no photos are returned', async () => {
-    mockedList.mockResolvedValue(createApiResponse([]));
+    mockedPostsList.mockResolvedValue(createApiResponse([]));
 
     renderWithProviders(<FeedPhotos onSelectPost={vi.fn()} />);
 
@@ -72,14 +87,24 @@ describe('FeedPhotos', () => {
 
   it('renders posts and selects a post by id', async () => {
     const onSelectPost = vi.fn();
-    mockedList.mockResolvedValue(createApiResponse(posts));
+    mockedPostsList.mockResolvedValue(createApiResponse(posts));
 
     renderWithProviders(<FeedPhotos user={7} onSelectPost={onSelectPost} />);
     await waitForElementToBeRemoved(() => screen.queryByRole('status'));
 
-    expect(mockedList).toHaveBeenCalledWith({ page: 1, perPage: 6 });
+    expect(mockedPostsList).toHaveBeenCalledWith({ page: 1, perPage: 6 });
     await userEvent.click(screen.getByRole('button', { name: /abrir detalhes do post nina/i }));
 
     expect(onSelectPost).toHaveBeenCalledWith('post-1');
+  });
+
+  it('renders legacy photos while the new API has no posts', async () => {
+    mockedPostsList.mockResolvedValue(createApiResponse([]));
+    mockedPhotosList.mockResolvedValue(createApiResponse(legacyPhotos));
+
+    renderWithProviders(<FeedPhotos onSelectPost={vi.fn()} />);
+
+    expect(await screen.findByRole('img', { name: 'Joel' })).toBeInTheDocument();
+    expect(mockedPhotosList).toHaveBeenCalledWith({ page: 1, total: 6, user: 0 });
   });
 });

--- a/src/Components/Feed/FeedPhotos.tsx
+++ b/src/Components/Feed/FeedPhotos.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from 'react';
 
-import { postsApi } from '@/api';
-import type { Post } from '@/types';
+import { photoApi, postsApi } from '@/api';
+import type { Photo, Post } from '@/types';
 import Error from '@components/Helper/Error';
 import Loading from '@components/Helper/Loading';
 import useFetch from '@hooks/useFetch';
 
-import { EmptyMessage, FeedList } from './FeedPhotos.styles';
+import { PhotoItem, PhotoTitle } from './FeedPhotosItem.styles';
+import { EmptyMessage, FeedList, LegacyPhotoContent } from './FeedPhotos.styles';
 import FeedPhotosItem from './FeedPhotosItem';
 
 type FeedPhotosProps = {
@@ -15,35 +16,60 @@ type FeedPhotosProps = {
 };
 
 const FeedPhotos = ({ user = 0, onSelectPost }: FeedPhotosProps) => {
-  const { data, loading, error, request } = useFetch<Post[]>();
+  const {
+    data: posts,
+    loading: postsLoading,
+    error: postsError,
+    request: requestPosts,
+  } = useFetch<Post[]>();
+  const {
+    data: legacyPhotos,
+    loading: legacyLoading,
+    error: legacyError,
+    request: requestLegacyPhotos,
+  } = useFetch<Photo[]>();
 
   useEffect(() => {
-    async function fetchPosts() {
-      await request(() =>
-        postsApi.list({
-          page: 1,
-          perPage: 6,
-        }),
-      );
+    async function fetchFeed() {
+      await Promise.all([
+        requestPosts(() => postsApi.list({ page: 1, perPage: 6 })),
+        requestLegacyPhotos(() => photoApi.list({ page: 1, total: 6, user: 0 })),
+      ]);
     }
-    fetchPosts();
-  }, [request, user]);
+    fetchFeed();
+  }, [requestLegacyPhotos, requestPosts, user]);
 
-  if (error) return <Error error={error} />;
-  if (loading) return <Loading />;
-  if (data && data.length === 0) {
+  const loading = postsLoading || legacyLoading;
+  const hasPosts = Boolean(posts?.length);
+  const hasLegacyPhotos = Boolean(legacyPhotos?.length);
+
+  if (loading && !posts && !legacyPhotos) return <Loading />;
+  if (!hasPosts && !hasLegacyPhotos && (postsError || legacyError)) {
+    return <Error error={postsError || legacyError} />;
+  }
+  if (!hasPosts && !hasLegacyPhotos) {
     return <EmptyMessage>Nenhum post encontrado.</EmptyMessage>;
   }
 
-  if (data)
-    return (
-      <FeedList className="animeLeft">
-        {data.map((post) => (
-          <FeedPhotosItem key={post.id} post={post} onSelect={() => onSelectPost(post.id)} />
-        ))}
-      </FeedList>
-    );
-  else return null;
+  return (
+    <FeedList className="animeLeft">
+      {posts?.map((post) => (
+        <FeedPhotosItem key={post.id} post={post} onSelect={() => onSelectPost(post.id)} />
+      ))}
+      {legacyPhotos?.map((photo) => {
+        const title = photo.title || photo.nome || 'Cachorro';
+
+        return (
+          <PhotoItem key={`legacy-${photo.id}`}>
+            <LegacyPhotoContent>
+              <img src={photo.src} alt={title} />
+              <PhotoTitle>{title}</PhotoTitle>
+            </LegacyPhotoContent>
+          </PhotoItem>
+        );
+      })}
+    </FeedList>
+  );
 };
 
 export default FeedPhotos;

--- a/src/Components/Helper/Loading.styles.ts
+++ b/src/Components/Helper/Loading.styles.ts
@@ -3,8 +3,10 @@ import styled from '@emotion/styled';
 export const LoadingMessage = styled.div`
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: ${({ theme }) => theme.spacing.md};
-  margin: ${({ theme }) => theme.spacing.xxl} 0;
+  min-height: 12rem;
+  margin: 0;
   color: ${({ theme }) => theme.colors.textMuted};
 
   &::before {

--- a/src/Components/Login/LoginPassword.test.tsx
+++ b/src/Components/Login/LoginPassword.test.tsx
@@ -46,6 +46,7 @@ describe('Login password recovery', () => {
   beforeEach(() => {
     mockedLost.mockReset();
     mockedReset.mockReset();
+    window.history.replaceState(null, '', '/');
   });
 
   it('validates the password lost form before submitting', async () => {
@@ -88,5 +89,20 @@ describe('Login password recovery', () => {
       });
     });
     expect(await screen.findByText('Senha redefinida com sucesso.')).toBeInTheDocument();
+  });
+
+  it('explains when the recovery link is expired', async () => {
+    window.history.replaceState(null, '', '/#error=access_denied&error_code=otp_expired');
+
+    renderPasswordReset('/login/resetar');
+
+    expect(
+      await screen.findByText(/este link de recuperação é inválido ou expirou/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /solicitar novo link/i })).toHaveAttribute(
+      'href',
+      '/login/perdeu',
+    );
+    expect(screen.queryByLabelText(/nova senha/i)).not.toBeInTheDocument();
   });
 });

--- a/src/Components/Login/LoginPasswordReset.tsx
+++ b/src/Components/Login/LoginPasswordReset.tsx
@@ -17,6 +17,7 @@ const LoginPasswordReset = () => {
   const { error, loading, request } = useFetch();
   const navigate = useNavigate();
   const [success, setSuccess] = useState<string | null>(null);
+  const recoveryError = new URLSearchParams(window.location.hash.slice(1)).get('error_code');
   const {
     register,
     handleSubmit,
@@ -44,18 +45,29 @@ const LoginPasswordReset = () => {
   return (
     <section className="animeLeft">
       <h1 className="title">Resetar senha</h1>
-      <Form onSubmit={handleSubmit(onSubmit)} noValidate>
-        <Input
-          label="Nova senha"
-          type="password"
-          error={errors.password?.message}
-          {...register('password')}
-        />
-        {loading ? <Button disabled>Redefinindo...</Button> : <Button>Redefinir Senha</Button>}
-        <Error error={error} />
-        {success && <StatusMessage variant="success">{success}</StatusMessage>}
-      </Form>
-      <LostPasswordLink to="/login">Voltar para login</LostPasswordLink>
+      {recoveryError ? (
+        <>
+          <StatusMessage variant="error">
+            Este link de recuperação é inválido ou expirou. Solicite um novo e-mail.
+          </StatusMessage>
+          <LostPasswordLink to="/login/perdeu">Solicitar novo link</LostPasswordLink>
+        </>
+      ) : (
+        <>
+          <Form onSubmit={handleSubmit(onSubmit)} noValidate>
+            <Input
+              label="Nova senha"
+              type="password"
+              error={errors.password?.message}
+              {...register('password')}
+            />
+            {loading ? <Button disabled>Redefinindo...</Button> : <Button>Redefinir Senha</Button>}
+            <Error error={error} />
+            {success && <StatusMessage variant="success">{success}</StatusMessage>}
+          </Form>
+          <LostPasswordLink to="/login">Voltar para login</LostPasswordLink>
+        </>
+      )}
     </section>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,17 @@ import { createRoot } from 'react-dom/client';
 
 import App from '@/App';
 
+const redirectedRoute = new URLSearchParams(window.location.search).get('__route');
+
+if (redirectedRoute) {
+  const routeUrl = new URL(redirectedRoute, window.location.origin);
+  window.history.replaceState(
+    null,
+    '',
+    `${routeUrl.pathname}${routeUrl.search}${window.location.hash}`,
+  );
+}
+
 const root = document.getElementById('root');
 
 if (!root) throw new Error('Root element not found.');


### PR DESCRIPTION
This commit addresses several issues:
- Enhances GitHub Pages deployment to correctly handle direct access and refreshes on SPA routes in both production and dev environments using a client-side 404 fallback.
- Implements a fallback mechanism in the feed to display legacy photos when the new posts API returns no results, ensuring content availability.
- Improves the password reset experience by showing a dedicated message when a recovery link has expired or is invalid.